### PR TITLE
DM-46578 Update DREAM mock so that it better matches reality +315-129

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,5 @@
 DevelopPipeline(
     name: "ts_dream",
     module_name: "lsst.ts.dream.csc",
-    idl_names: ["DREAM"],
-    extra_packages: ["lsst-ts/ts_dream_common"],
+    idl_names: ["DREAM"]
 )

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,6 +15,7 @@ test:
     - ts-conda-build =0.4
     - ts-idl {{ idl_version }}
     - ts-salobj {{ salobj_version }}
+    - ts-tcpip
   source_files:
     - python
     - tests
@@ -38,3 +39,4 @@ requirements:
     - setuptools_scm
     - ts-salobj
     - ts-idl
+    - ts-tcpip

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,7 +13,6 @@ build:
 test:
   requires:
     - ts-conda-build =0.4
-    - ts-idl {{ idl_version }}
     - ts-salobj {{ salobj_version }}
     - ts-tcpip
   source_files:
@@ -38,5 +37,4 @@ requirements:
     - setuptools
     - setuptools_scm
     - ts-salobj
-    - ts-idl
     - ts-tcpip

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -7,15 +7,14 @@ source:
   path: ../
 
 build:
-  noarch: generic
+  noarch: python
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
   entry_points:
     - run_dream = lsst.ts.dream.csc:run_dream
 
 test:
   requires:
-    - ts-conda-build
-    - ts-dream-common
+    - ts-conda-build =0.4
     - ts-idl {{ idl_version }}
     - ts-salobj {{ salobj_version }}
     - ts-tcpip
@@ -41,8 +40,6 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
-    - ts-dream-common
-    - ts-idl
     - ts-salobj
     - ts-tcpip
     - ts-xml

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,7 +17,6 @@ test:
     - ts-salobj {{ salobj_version }}
   source_files:
     - python
-    - bin
     - tests
     - pyproject.toml
   commands:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
+    - ts-idl
     - ts-salobj
     - ts-tcpip
     - ts-xml

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 {% set data= load_setup_py_data() %}
 package:
-  name: "ts-dream"
+  name: ts-dream
   version: {{ data.get('version') }}
 
 source:
@@ -9,38 +9,33 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
-  entry_points:
-    - run_dream = lsst.ts.dream.csc:run_dream
 
 test:
   requires:
     - ts-conda-build =0.4
     - ts-idl {{ idl_version }}
     - ts-salobj {{ salobj_version }}
-    - ts-tcpip
-    - ts-xml
   source_files:
     - python
+    - bin
     - tests
+    - pyproject.toml
   commands:
     - pytest
 
 requirements:
   host:
-    - python
+    - python  {{ python }}
     - pip
     - setuptools_scm
     - setuptools
-    - pytest-runner
   build:
     - python {{ python }}
     - setuptools_scm
     - setuptools
   run:
-    - python
+    - python {{ python }}
     - setuptools
     - setuptools_scm
-    - ts-idl
     - ts-salobj
-    - ts-tcpip
-    - ts-xml
+    - ts-idl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ license = { text = "GPL" }
 classifiers = [ "Programming Language :: Python :: 3" ]
 urls = { documentation = "https://ts-dream.lsst.io", source_code = "https://github.com/lsst-ts/ts_dream" }
 dynamic = ["version"]
+dependencies = [
+    "ts_tcpip",
+]
 
 [tool.setuptools.dynamic]
 version = { attr = "setuptools_scm.get_version" }
@@ -31,4 +34,4 @@ __version__ = "{version}"
 asyncio_mode = "auto"
 
 [project.optional-dependencies]
-dev = ["pytest", "black", "flake8", "documenteer[pipelines]"]
+dev = ["documenteer[pipelines]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "setuptools", "setuptools_scm" ]
+requires = ["setuptools>=45", "setuptools-scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,23 +7,17 @@ name = "ts-dream"
 description = "DREAM camera CSC."
 license = { text = "GPL" }
 classifiers = [ "Programming Language :: Python :: 3" ]
-urls = { documentation = "https://ts-dream.lsst.io", repository = "https://github.com/lsst-ts/ts_dream" }
-dynamic = [ "version" ]
-dependencies = [
-  "pyyaml",
-  "Cython",
-  "ts_salobj",
-  "ts_utils",
-]
-
-[project.scripts]
-run_dream = "lsst.ts.dream.csc:run_dream"
+urls = { documentation = "https://ts-dream.lsst.io", source_code = "https://github.com/lsst-ts/ts_dream" }
+dynamic = ["version"]
 
 [tool.setuptools.dynamic]
 version = { attr = "setuptools_scm.get_version" }
 
 [tool.setuptools.packages.find]
 where = [ "python" ]
+
+[project.scripts]
+run_dream = "lsst.ts.dream.csc:run_dream"
 
 [tool.setuptools_scm]
 write_to = "python/lsst/ts/dream/csc/version.py"
@@ -37,4 +31,4 @@ __version__ = "{version}"
 asyncio_mode = "auto"
 
 [project.optional-dependencies]
-dev = ["documenteer[pipelines]"]
+dev = ["pytest", "black", "flake8", "documenteer[pipelines]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dynamic = [ "version" ]
 dependencies = [
   "pyyaml",
   "Cython",
-  "ts_dream_common",
   "ts_salobj",
   "ts_utils",
 ]

--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -104,7 +104,7 @@ class DreamCsc(salobj.ConfigurableCsc):
             Command ID and data
         """
         await super().begin_enable(id_data)
-        self.cmd_enable.ack_in_progress(id_data, timeout=60)
+        await self.cmd_enable.ack_in_progress(id_data, timeout=60)
 
     async def end_enable(self, id_data: salobj.BaseDdsDataType) -> None:
         """End do_enable; called after state changes but before command
@@ -132,7 +132,7 @@ class DreamCsc(salobj.ConfigurableCsc):
         id_data: `CommandIdData`
             Command ID and data
         """
-        self.cmd_disable.ack_in_progress(id_data, timeout=60)
+        await self.cmd_disable.ack_in_progress(id_data, timeout=60)
         await super().begin_disable(id_data)
 
     async def disconnect(self) -> None:

--- a/python/lsst/ts/dream/csc/mock/mock_dream.py
+++ b/python/lsst/ts/dream/csc/mock/mock_dream.py
@@ -25,11 +25,120 @@ import asyncio
 import json
 import logging
 import socket
-import time
 import typing
 
 from lsst.ts import tcpip
 
+_dream_status = """
+{
+  "status": {
+    "target_observing_mode": "IDLE",
+    "actual_observing_mode": "IDLE",
+    "target_dome_state": "STOP",
+    "actual_dome_state": "STOP",
+    "target_heater_state": "OFF",
+    "actual_heater_state": "OFF",
+    "target_peltier_state": "OFF",
+    "actual_peltier_state": "OFF",
+    "temp_hum": {
+      "electronics_top": {
+        "temperature": 25.76363921680424,
+        "humidity": 50.671024074507606
+      },
+      "camera_bay": {
+        "temperature": 25.960600848565594,
+        "humidity": 50.380806542848525
+      },
+      "electronics_box": {
+        "temperature": 25.842814592491973,
+        "humidity": 50.311423547799194
+      },
+      "rack_top": {
+        "temperature": 25.148454997628154,
+        "humidity": 50.35500642777455
+      },
+      "rack_bottom": {
+        "temperature": 25.177524512769548,
+        "humidity": 50.548822284540506
+      },
+      "dream_inlet": {
+        "temperature": 25.188939326407745,
+        "humidity": 50.46328238367049
+      }
+    },
+    "pdu_status": {
+      "Switch": true,
+      "USB hub": true,
+      "PSU 1": true,
+      "PSU 2": true,
+      "Central Camera": true,
+      "North Camera": true,
+      "East Camera": true,
+      "Command Server": true,
+      "Central Server": true,
+      "North Server": true,
+      "East Server": true,
+      "South Server": true,
+      "West Server": true,
+      "South Camera": true,
+      "West Camera": true
+    },
+    "ups_status": {
+      "ups_status": "ONLINE",
+      "battery_charge": 100,
+      "battery_temperature": 30.053783855218214,
+      "battery_voltage": 48.95089981581298,
+      "battery_remaining": 50,
+      "battery_needs_replacing": false,
+      "input_last_error": "no error",
+      "output_load": 25.514144279491916,
+      "output_current": 2.4332511053654104,
+      "last_online": 1728426033.012355
+    },
+    "psu_status": {
+      "temp_error": false,
+      "input_error": false,
+      "voltage_feedback": 0.04051622113408792,
+      "current_feedback": 0.0008196898088569571,
+      "voltage_setpoint": 0,
+      "current_setpoint": 20
+    },
+    "limit_switches": {
+      "front_door": "hit",
+      "back_door": "hit",
+      "dome_open": "not hit",
+      "dome_closed": "not hit"
+    },
+    "electronics": {
+      "motor_relay": "off",
+      "motor_dir": "closing",
+      "peltier_relay": "off",
+      "peltier_dir": "heating",
+      "window_heaters": "off"
+    },
+    "dome_position": 110,
+    "errors": [
+      "Dome should be closed but it is not"
+    ],
+    "warnings": [
+      "North camera not connected",
+      "East camera not connected",
+      "South camera not connected",
+      "Dome movements are simulated",
+      "Temp/humidity sensors are simulated",
+      "LEDs are simulated",
+      "User stopped dome movement",
+      "More than 1 client on rubin socket",
+      "PDU is simulated",
+      "West camera not connected",
+      "Center camera not connected",
+      "Dome opening blocked by sun alt",
+      "UPS is simulated"
+    ],
+    "cameras": {}
+  }
+}
+"""
 
 class MockDream(tcpip.OneClientServer):
     """A mock DREAM server for exchanging messages that talks over TCP/IP.
@@ -184,7 +293,7 @@ class MockDream(tcpip.OneClientServer):
 
         return {
             "msg_type": "status",
-            "status": dict(),
+            "status": json.loads(_dream_status),
         }
 
     async def get_new_data_products(self, data: bool | None) -> dict:

--- a/python/lsst/ts/dream/csc/mock/mock_dream.py
+++ b/python/lsst/ts/dream/csc/mock/mock_dream.py
@@ -140,6 +140,7 @@ _dream_status = """
 }
 """
 
+
 class MockDream(tcpip.OneClientServer):
     """A mock DREAM server for exchanging messages that talks over TCP/IP.
 

--- a/python/lsst/ts/dream/csc/model/dream_model.py
+++ b/python/lsst/ts/dream/csc/model/dream_model.py
@@ -24,7 +24,6 @@ __all__ = ["DreamModel"]
 import asyncio
 import json
 import logging
-import time
 from typing import Any, Dict, List, Optional, Union
 
 from lsst.ts import tcpip, utils
@@ -154,7 +153,7 @@ class DreamModel:
                     pass
         except tcpip.IncompleteReadError:
             self.log.info("Connection closed by server")
-        except Exception as e:
+        except Exception:
             self.log.exception("_read_loop failed")
             raise
 

--- a/python/lsst/ts/dream/csc/model/dream_model.py
+++ b/python/lsst/ts/dream/csc/model/dream_model.py
@@ -122,19 +122,17 @@ class DreamModel:
         if not self.writer or not self.connected:
             raise RuntimeError("Not connected")
 
-        cmd_id: int = next(self.index_generator)
-        time_command_sent: float = time.time()
+        request_id: int = next(self.index_generator)
         st = json.dumps(
             {
-                "command": command,
-                "cmd_id": cmd_id,
-                "time_command_sent": time_command_sent,
+                "action": command,
+                "request_id": request_id,
                 **data,
             }
         )
         self.writer.write(st.encode() + tcpip.TERMINATOR)
         await self.writer.drain()
-        self.sent_commands.append(cmd_id)
+        self.sent_commands.append(request_id)
 
     async def _read_loop(self) -> None:
         """Execute a loop that reads incoming data from the SocketServer."""
@@ -142,20 +140,23 @@ class DreamModel:
             while True:
                 data = await self.read()
                 self.log.info(f"Received data {data!r}")
-                if "cmd_id" in data:
-                    if not data["cmd_id"] in self.sent_commands:
+                if "request_id" in data:
+                    if data["request_id"] not in self.sent_commands:
                         self.log.error(
-                            f"Received a reply to an unknown cmd ID {data['cmd_id']}."
+                            f"Received a reply to an unknown cmd ID {data['request_id']}."
                         )
                     else:
                         # TODO Properly handle command execution tracing.
-                        self.received_cmd_ids.append(data["cmd_id"])
-                        self.sent_commands.remove(data["cmd_id"])
+                        self.received_cmd_ids.append(data["request_id"])
+                        self.sent_commands.remove(data["request_id"])
                 else:
                     # TODO implement handling of messages from DREAM
                     pass
-        except Exception:
+        except tcpip.IncompleteReadError:
+            self.log.info("Connection closed by server")
+        except Exception as e:
             self.log.exception("_read_loop failed")
+            raise
 
     async def disconnect(self) -> None:
         """Disconnect, if connected."""

--- a/tests/test_mock_dream.py
+++ b/tests/test_mock_dream.py
@@ -120,8 +120,16 @@ class MockDreamTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["result"], "error")
 
     async def test_commands_without_params(self):
-        for action in ["getStatus", "getNewDataProducts", "setWeather", "setRoof", "heartbeat"]:
-            await self.verify_command(action=action, data=True)  # Some commands require "data".
+        for action in [
+            "getStatus",
+            "getNewDataProducts",
+            "setWeather",
+            "setRoof",
+            "heartbeat",
+        ]:
+            await self.verify_command(
+                action=action, data=True
+            )  # Some commands require "data".
 
     async def test_heartbeat(self):
         await self.verify_command(action="heartbeat")

--- a/tests/test_mock_dream.py
+++ b/tests/test_mock_dream.py
@@ -24,6 +24,7 @@
 import asyncio
 import json
 import logging
+import random
 import unittest
 
 from lsst.ts import tcpip
@@ -32,6 +33,8 @@ from lsst.ts.dream.csc.mock import MockDream
 logging.basicConfig(
     format="%(asctime)s:%(levelname)s:%(name)s:%(message)s", level=logging.DEBUG
 )
+
+random.seed(42)
 
 """Standard timeout in seconds."""
 TIMEOUT = 5
@@ -111,7 +114,7 @@ class MockDreamTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def verify_error(self, action, **kwargs):
         self.assertTrue(self.srv.connected)
-        request_id = 1
+        request_id = random.randint(2, 5000)
         await self.write(action=action, request_id=request_id, **kwargs)
         # Give time to the socket server to process the command.
         await asyncio.sleep(0.5)

--- a/tests/test_mock_dream.py
+++ b/tests/test_mock_dream.py
@@ -24,7 +24,6 @@
 import asyncio
 import json
 import logging
-import time
 import unittest
 
 from lsst.ts import tcpip
@@ -96,51 +95,49 @@ class MockDreamTestCase(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0.5)
         self.assertFalse(self.srv.connected)
 
-    async def verify_command(self, command, parameters=None):
+    async def verify_command(self, action, **kwargs):
         self.assertTrue(self.srv.connected)
-        cmd_id = 1
-        time_command_sent = time.time()
-        if parameters:
-            await self.write(
-                command=command,
-                cmd_id=cmd_id,
-                time_command_sent=time_command_sent,
-                parameters=parameters,
-            )
-        else:
-            await self.write(
-                command=command,
-                cmd_id=cmd_id,
-                time_command_sent=time_command_sent,
-            )
+        request_id = 1
+        await self.write(
+            action=action,
+            request_id=request_id,
+            **kwargs,
+        )
         # Give time to the socket server to process the command.
         await asyncio.sleep(0.5)
         data = await self.read()
-        self.assertEqual(data["cmd_id"], cmd_id)
-        self.assertGreater(data["time_command_received"], time_command_sent)
-        self.assertGreater(data["time_ack_sent"], data["time_command_received"])
-        self.assertEqual(data["response"], "OK")
+        self.assertEqual(data["request_id"], request_id)
+        self.assertEqual(data["result"], "ok")
+
+    async def verify_error(self, action, **kwargs):
+        self.assertTrue(self.srv.connected)
+        request_id = 1
+        await self.write(action=action, request_id=request_id, **kwargs)
+        # Give time to the socket server to process the command.
+        await asyncio.sleep(0.5)
+        data = await self.read()
+        self.assertEqual(data["request_id"], request_id)
+        self.assertEqual(data["result"], "error")
 
     async def test_commands_without_params(self):
-        for command in ["resume", "openRoof", "closeRoof", "stop", "dataArchived"]:
-            await self.verify_command(command=command)
+        for action in ["getStatus", "getNewDataProducts", "setWeather", "setRoof", "heartbeat"]:
+            await self.verify_command(action=action, data=True)  # Some commands require "data".
 
-    async def test_ready_for_data(self):
-        await self.verify_command(command="readyForData", parameters={"ready": False})
+    async def test_heartbeat(self):
+        await self.verify_command(action="heartbeat")
 
-    async def test_set_weather_info(self):
-        await self.verify_command(
-            command="setWeatherInfo",
-            parameters={
-                "weather_info": {
-                    "temperature": 5.7,
-                    "humidity": 15,
-                    "wind_speed": 12,
-                    "wind_direction": 334,
-                    "pressure": 101320,
-                    "rain": 0,
-                    "cloudcover": 0,
-                    "safe_observing_conditions": True,
-                }
-            },
-        )
+    async def test_set_weather(self):
+        await self.verify_error(action="setWeather")
+        await self.verify_command(action="setWeather", data=True)
+        await self.verify_command(action="setWeather", data=False)
+
+    async def test_set_roof(self):
+        await self.verify_error(action="setRoof")
+        await self.verify_command(action="setRoof", data=True)
+        await self.verify_command(action="setRoof", data=False)
+
+    async def test_get_new_data_products(self):
+        await self.verify_command(action="getNewDataProducts")
+
+    async def test_get_status(self):
+        await self.verify_command(action="getStatus")

--- a/ups/ts_dream.table
+++ b/ups/ts_dream.table
@@ -5,7 +5,6 @@
 setupRequired(sconsUtils)
 setupRequired(ts_salobj)
 setupRequired(ts_tcpip)
-setupRequired(ts_dream_common)
 
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
This PR covers modifications to the DREAM mock to make it match the implementation of DREAM. You can see this implementation at:
https://bitbucket.org/radboudradiolab/dreamcontrol/src/main/engineering/mock_rubin.py

First, a change in terminology: "command" becomes "action", "cmd_id" becomes "request_id", etc. Second, a change in the set of commands: the commands implemented are `setRoof`, `setWeather`, `getStatus`, `getNewDataProducts`, `heartbeat`.

This PR also includes some modifications to make it generate a conda package in Jenkins. There are probably a lot of changes that are not really necessary, but I was struggling to find the reason for the failure. (Sorry Petr for the barrage of failure emails probably in your inbox.) 

The dependency on `ts_dream_common` is removed. If the team in the Netherlands were using it, that resource would be useful. Since they are not using it, I don't see any need to keep it around.