### PR TITLE
DM-47718 Minor DREAM cleanups

### DIFF
--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -182,7 +182,11 @@ class DreamCsc(salobj.ConfigurableCsc):
             self.mock = None
 
         self.weather_loop_task.cancel()
-        await self.weather_loop_task
+        try:
+            await self.weather_loop_task
+        except asyncio.CancelledError:
+            # This is expected.
+            pass
 
         if self.ess_remote is not None:
             await self.ess_remote.close()

--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -245,7 +245,7 @@ class DreamCsc(salobj.ConfigurableCsc):
                     if air_flow is None or air_flow.speed > 25:
                         weather_ok_flag = False
 
-                    precipitation = await self.ess_remote.evt_precipitation.get()
+                    precipitation = self.ess_remote.evt_precipitation.get()
                     if precipitation is None or (
                         precipitation.raining or precipitation.snowing
                     ):
@@ -255,6 +255,7 @@ class DreamCsc(salobj.ConfigurableCsc):
                     if self.ess_remote is not None:
                         await self.ess_remote.close()
                         self.ess_remote = None
+                    await asyncio.sleep(180)  # A little extra safety
                     continue
 
             else:

--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -129,6 +129,7 @@ class DreamCsc(salobj.ConfigurableCsc):
             if self.model is None:
                 self.model = DreamModel(config=self.config, log=self.log)
             await self.model.connect(host=host, port=port)
+            await self.model.open_roof()
 
         except Exception as e:
             err_msg = f"Could not open connection to host={host}, port={port}: {e!r}"
@@ -175,6 +176,7 @@ class DreamCsc(salobj.ConfigurableCsc):
 
         self.log.info("Disconnecting")
         if self.model is not None:
+            await self.model.close_roof()
             await self.model.disconnect()
         self.model = None
         if self.mock:

--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -233,6 +233,9 @@ class DreamCsc(salobj.ConfigurableCsc):
                         self.log.error("Failed to connect to weather CSC.")
                         continue
 
+                    # Wait for the CSC to establish its connection.
+                    await asyncio.sleep(10.0)
+
                 try:
                     # Get weather data.
                     weather_ok_flag = True
@@ -287,6 +290,7 @@ class DreamCsc(salobj.ConfigurableCsc):
                 await self.weather_sleep_task
             except asyncio.CancelledError:
                 self.log.info("Weather loop ending because of asyncio cancel.")
+                raise
 
 
 def run_dream() -> None:

--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -250,9 +250,8 @@ class DreamCsc(salobj.ConfigurableCsc):
                     if air_flow is None or air_flow.speed > 25:
                         weather_ok_flag = False
 
-                    precipitation = await self.ess_remote.evt_precipitation.next(
-                        flush=True,
-                        timeout=10,
+                    precipitation = await self.ess_remote.evt_precipitation.aget(
+                        timeout=10
                     )
                     if precipitation is None or (
                         precipitation.raining or precipitation.snowing

--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -241,14 +241,14 @@ class DreamCsc(salobj.ConfigurableCsc):
                     weather_ok_flag = True
                     air_flow = await self.ess_remote.tel_airFlow.next(
                         flush=True,
-                        timeout=2,
+                        timeout=10,
                     )
                     if air_flow is None or air_flow.speed > 25:
                         weather_ok_flag = False
 
                     precipitation = await self.ess_remote.evt_precipitation.next(
                         flush=True,
-                        timeout=2,
+                        timeout=10,
                     )
                     if precipitation is None or (
                         precipitation.raining or precipitation.snowing


### PR DESCRIPTION
This work encompasses a few different tasks:

- Correct the behavior of the CSC's interaction with telemetry and events from the weather CSC
- Send the setWeather command to DREAM even when the weather status hasn't changed, as expected by DREAM
- Use the setRoof command to advise DREAM to open, as expected by DREAM

Some further cleanup is needed in the initialization and summary state changes for this CSC, but that cleanup is under the scope of DM-48147.