### PR TITLE
Catch exception while disconnecting

### DIFF
--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -179,7 +179,10 @@ class DreamCsc(salobj.ConfigurableCsc):
 
         self.log.info("Disconnecting")
         if self.model is not None:
-            await self.model.close_roof()
+            try:
+                await self.model.close_roof()
+            except Exception:
+                self.log.exception("While disconnecting, failed to close the roof.")
             await self.model.disconnect()
         self.model = None
         if self.mock:


### PR DESCRIPTION
The basic problem here is that the CSC is trying to close the roof when disconnecting, but it was already disconnected. This raises two questions in my mind: (1) why didn't the CSC go to fault, and (2) should the CSC go to fault instead of ignoring the failure to close? The latter may not matter much considering the internal protections in DREAM.