### PR TITLE
DM-48708 Add some of the CSC events

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -8,6 +8,7 @@ v0.5.0
 ======
 
 * Implemented the telemetry items.
+* Added `alerts`, `errors`, `temperatureControl`, and `ups` events.
 
 v0.4.0
 ======

--- a/python/lsst/ts/dream/csc/config_schema.py
+++ b/python/lsst/ts/dream/csc/config_schema.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = yaml.safe_load(
     $schema: http://json-schema.org/draft-07/schema#
     $id: https://github.com/lsst-ts/ts_dream/blob/master/python/lsst/ts/dream/csc/config_schema.py
     # title must end with one or more spaces followed by the schema version, which must begin with "v"
-    title: DREAM v2
+    title: DREAM v3
     description: Schema for DREAM configuration files
     type: object
     properties:
@@ -61,6 +61,12 @@ CONFIG_SCHEMA = yaml.safe_load(
         type: number
         minimum: 0
         default: 301
+      battery_low_threshold:
+        description: Percent charge on the UPS battery that is considered "low"
+        type: number
+        minimum: 0
+        exclusiveMaximum: 100
+        default: 25
     required:
       - host
       - port

--- a/python/lsst/ts/dream/csc/mock/mock_dream.py
+++ b/python/lsst/ts/dream/csc/mock/mock_dream.py
@@ -118,7 +118,9 @@ _dream_status = """
     },
     "dome_position": 110,
     "errors": [
-      "Dome should be closed but it is not"
+      "Dome should be closed but it is not",
+      "Temp hum sensor not reachable",
+      "PDU 2 not reachable"
     ],
     "warnings": [
       "North camera not connected",


### PR DESCRIPTION
This PR adds three of the events defined by the CSC: alerts, temperatureControl, and ups.

There's some degree of trying to jam a square peg into a round hole. The information provided by DREAM does not always match the information expected by the CSC. I've done my best to work around that. A better (and probably necessary) alternative is to refine the XML to better match the way DREAM is implemented. But I prefer to start with this approach as a partial solution and to come back later with revised XML.

This PR expands on the work in PR-10 in this repo: https://github.com/lsst-ts/ts_dream/pull/10

See also PR-374 in ts_config_ocs: https://github.com/lsst-ts/ts_config_ocs/pull/374