### PR TITLE
DM-48944 DREAM should send files to LFA

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -4,6 +4,11 @@
 Version History
 ###############
 
+v0.5.1
+======
+
+* Implemented the getNewDataProducts command.
+
 v0.5.0
 ======
 

--- a/python/lsst/ts/dream/csc/config_schema.py
+++ b/python/lsst/ts/dream/csc/config_schema.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = yaml.safe_load(
     $schema: http://json-schema.org/draft-07/schema#
     $id: https://github.com/lsst-ts/ts_dream/blob/master/python/lsst/ts/dream/csc/config_schema.py
     # title must end with one or more spaces followed by the schema version, which must begin with "v"
-    title: DREAM v3
+    title: DREAM v4
     description: Schema for DREAM configuration files
     type: object
     properties:
@@ -67,6 +67,14 @@ CONFIG_SCHEMA = yaml.safe_load(
         minimum: 0
         exclusiveMaximum: 100
         default: 25
+      s3instance:
+        description: >-
+          Large File Annex S3 instance, for example "cp", "tuc" or  "ls".
+        type: string
+        pattern: "^[a-z0-9][.a-z0-9]*[a-z0-9]$"
+      url_root:
+        description: Root URL where DREAM data products are found.
+        type: string
     required:
       - host
       - port
@@ -74,6 +82,8 @@ CONFIG_SCHEMA = yaml.safe_load(
       - read_timeout
       - poll_interval
       - ess_index
+      - s3instance
+      - url_root
     additionalProperties: false
     """
 )

--- a/python/lsst/ts/dream/csc/config_schema.py
+++ b/python/lsst/ts/dream/csc/config_schema.py
@@ -72,8 +72,8 @@ CONFIG_SCHEMA = yaml.safe_load(
           Large File Annex S3 instance, for example "cp", "tuc" or  "ls".
         type: string
         pattern: "^[a-z0-9][.a-z0-9]*[a-z0-9]$"
-      url_root:
-        description: Root URL where DREAM data products are found.
+      data_product_path:
+        description: Local filesystem path for fallback storage of data products
         type: string
     required:
       - host
@@ -83,7 +83,7 @@ CONFIG_SCHEMA = yaml.safe_load(
       - poll_interval
       - ess_index
       - s3instance
-      - url_root
+      - data_product_path
     additionalProperties: false
     """
 )

--- a/python/lsst/ts/dream/csc/mock/dream_mock_http.py
+++ b/python/lsst/ts/dream/csc/mock/dream_mock_http.py
@@ -1,0 +1,68 @@
+# This file is part of ts_dream.
+#
+# Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import random
+
+from aiohttp import web
+
+
+class MockDreamHTTPServer:
+    """A simple HTTP server for unit testing of DREAM."""
+
+    def __init__(self, host: str = "localhost", port: int = 0):
+        self.host = host
+        self.port = port if port != 0 else random.randint(1024, 65535)
+        self.app = web.Application()
+        self.app.add_routes(
+            [
+                web.get("/product1.txt", self.handle_request),
+                web.get("/product2.txt", self.handle_request),
+                web.get("/product3.txt", self.handle_request),
+                web.get("/product4.txt", self.handle_request),
+            ]
+        )
+        self.runner = None
+        self.files = {
+            "/product1.txt": "This is data product 1",
+            "/product2.txt": "This is data product 2",
+            "/product3.txt": "This is data product 3",
+            "/product4.txt": "This is data product 4",
+        }
+
+    async def handle_request(self, request: web.Request) -> web.Response:
+        if request.path in self.files:
+            return web.Response(
+                text=self.files[request.path], content_type="text/plain"
+            )
+        return web.Response(status=404, text="File not found")
+
+    async def start(self) -> None:
+        """Start the HTTP server asynchronously."""
+        self.runner = web.AppRunner(self.app)
+        assert self.runner is not None
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, self.host, self.port)
+        await site.start()
+
+    async def stop(self) -> None:
+        """Stop the HTTP server."""
+        if self.runner:
+            await self.runner.cleanup()

--- a/python/lsst/ts/dream/csc/model/__init__.py
+++ b/python/lsst/ts/dream/csc/model/__init__.py
@@ -19,4 +19,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .dream_model import DreamModel
+from .dream_model import DataProduct, DreamModel

--- a/python/lsst/ts/dream/csc/model/dream_model.py
+++ b/python/lsst/ts/dream/csc/model/dream_model.py
@@ -19,14 +19,45 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["DreamModel"]
+__all__ = ["DataProduct", "DreamModel"]
 
 import asyncio
 import logging
+from dataclasses import asdict, dataclass
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Literal, Type, TypeVar
 
+from astropy.time import Time
 from lsst.ts import tcpip, utils
+
+T = TypeVar("T", bound="DataProduct")
+
+
+@dataclass
+class DataProduct:
+    kind: Literal["cloud", "image", "calibration", "lightcurve"]
+    type: Literal["dark", "flat", "bias", "science"] | None
+    seq: list[int]
+    start: Time
+    end: Time
+    server: Literal["N", "E", "S", "W", "C", "B"]
+    size: int  # in bytes
+    filename: str
+    sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert dataclass to dictionary with time in ISO format."""
+        data = asdict(self)
+        data["start"] = self.start.iso
+        data["end"] = self.end.iso
+        return data
+
+    @classmethod
+    def from_dict(cls: Type[T], data: dict[str, Any]) -> T:
+        """Build a dataclass object from dictionary with time in ISO format."""
+        data["start"] = Time(data["start"])
+        data["end"] = Time(data["end"])
+        return cls(**data)
 
 
 class DreamModel:
@@ -190,3 +221,34 @@ class DreamModel:
             raise RuntimeError("Unexpected format for status message!")
 
         return response["status"]
+
+    async def get_new_data_products(self) -> list[DataProduct]:
+        """Queries whether new data products are available from DREAM.
+
+        New data products are made available from DREAM via HTTP. A
+        query with this command provides the URL and other metadata
+        associated with these data products. The DREAM CSC should
+        collect these products and load them to the LFA.
+
+        Returns
+        -------
+        list[DataProduct]
+            A list of new data product items reported by DREAM.
+
+        Raises
+        ------
+        RuntimeError
+            If DREAM responds in an unexpected way.
+        """
+        response = await self.write(command="getNewDataProducts")
+        if response["msg_type"] != "list":
+            self.log.error(
+                f"In getStatus, received unexpected message type: {response['msg_type']}"
+            )
+            raise RuntimeError(
+                f"In getStatus, received unexpected message type: {response['msg_type']}"
+            )
+        if "new_products" not in response:
+            self.log.error("Unexpected format for getNewDataProducts message!")
+            raise RuntimeError("Unexpected format for getNewDataProducts message!")
+        return [DataProduct.from_dict(dp) for dp in response["new_products"]]

--- a/tests/config/_init.yaml
+++ b/tests/config/_init.yaml
@@ -6,4 +6,4 @@ poll_interval: 10
 ess_index: 301
 battery_low_threshold: 25
 s3instance: test
-url_root: http://localhost:8000/dream/
+data_product_path: /tmp

--- a/tests/config/_init.yaml
+++ b/tests/config/_init.yaml
@@ -1,0 +1,9 @@
+host: "127.0.0.1"
+port: 5000
+connection_timeout: 10
+read_timeout: 10
+poll_interval: 10
+ess_index: 301
+battery_low_threshold: 25
+s3instance: test
+url_root: http://localhost:8000/dream/

--- a/tests/config/_test.yaml
+++ b/tests/config/_test.yaml
@@ -1,0 +1,1 @@
+url_root: http://localhost:53841

--- a/tests/config/_test.yaml
+++ b/tests/config/_test.yaml
@@ -1,1 +1,1 @@
-url_root: http://localhost:53841
+data_product_path: "/tmp"

--- a/tests/test_dream_csc.py
+++ b/tests/test_dream_csc.py
@@ -239,9 +239,9 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                     "S_calibration_000057_000047.txt",
                     "B_image_bias_000017_000080.txt",
                 ]
-                for i, key_ending in enumerate(file_index):
+                for j, key_ending in enumerate(file_index):
                     if key.endswith(key_ending):
-                        self.assertEqual(file_contents, f"This is data product {i+1}")
+                        self.assertEqual(file_contents, f"This is data product {j+1}")
                         break
 
     async def test_data_upload_failure(self):

--- a/tests/test_dream_csc.py
+++ b/tests/test_dream_csc.py
@@ -232,7 +232,17 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 key = url[url.index("DREAM/") :]
                 fileobj = await self.csc.s3bucket.download(key=key)
                 file_contents = fileobj.getvalue().decode("utf-8")
-                self.assertEqual(file_contents, f"This is data product {i}")
+
+                file_index = [
+                    "N_cloud_flat_000041_000073.txt",
+                    "W_cloud_science_000019_000056.txt",
+                    "S_calibration_000057_000047.txt",
+                    "B_image_bias_000017_000080.txt",
+                ]
+                for i, key_ending in enumerate(file_index):
+                    if key.endswith(key_ending):
+                        self.assertEqual(file_contents, f"This is data product {i+1}")
+                        break
 
     async def test_data_upload_failure(self):
         """Test that the CSC enters FAULT state if the data upload fails."""

--- a/tests/test_dream_csc.py
+++ b/tests/test_dream_csc.py
@@ -40,7 +40,7 @@ logging.basicConfig(
 
 class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
-        self.http_server = MockDreamHTTPServer(port=53841)
+        self.http_server = MockDreamHTTPServer(port=5001)
         await self.http_server.start()
 
         self.srv = dream_csc.mock.MockDream(

--- a/tests/test_dream_model.py
+++ b/tests/test_dream_model.py
@@ -73,3 +73,8 @@ class DreamModelTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_get_status(self):
         status = await self.model.get_status()
         self.assertEqual(status["target_observing_mode"], "IDLE")
+
+    async def test_get_products(self):
+        products = await self.model.get_new_data_products()
+        self.assertEqual(len(products), 4)
+        self.assertEqual(products[0].filename, "product1.txt")

--- a/tests/test_mock_dream.py
+++ b/tests/test_mock_dream.py
@@ -157,3 +157,12 @@ class MockDreamTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_get_status(self):
         data = await self.verify_command(action="getStatus")
         self.assertEqual(data["status"]["target_observing_mode"], "IDLE")
+
+    async def test_get_products(self):
+        data = await self.verify_command(action="getNewDataProducts")
+        new_products = data["new_products"]
+        self.assertEqual(len(new_products), 4)
+        self.assertEqual(
+            new_products[0]["sha256"],
+            "23ff1547b9c233d672a844a319429224973d3d80f875db7e06c6264fb066d9a2",
+        )


### PR DESCRIPTION
This patch adds functionality to the DREAM CSC to use the getNewDataProducts command from DREAM. For each new data product, it sets up a key on the LFA and uploads the file. If upload to the LFA fails, it saves the file in the `/tmp` directory.

Note that this creates significant extra requirements for disk storage for the DREAM CSC. Given how rapidly DREAM generates data it may not be worth the effort to save data on the local disk as a fallback, and to just accept lost data whenever the LFA is unavailable.