### PR TITLE
OSW-499: Allow DREAM to get data products from multiple HTTP servers.

### DIFF
--- a/python/lsst/ts/dream/csc/config_schema.py
+++ b/python/lsst/ts/dream/csc/config_schema.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = yaml.safe_load(
     $schema: http://json-schema.org/draft-07/schema#
     $id: https://github.com/lsst-ts/ts_dream/blob/master/python/lsst/ts/dream/csc/config_schema.py
     # title must end with one or more spaces followed by the schema version, which must begin with "v"
-    title: DREAM v5
+    title: DREAM v6
     description: Schema for DREAM configuration files
     type: object
     properties:
@@ -72,11 +72,37 @@ CONFIG_SCHEMA = yaml.safe_load(
           Large File Annex S3 instance, for example "cp", "tuc" or  "ls".
         type: string
         pattern: "^[a-z0-9][.a-z0-9]*[a-z0-9]$"
+      data_product_host:
+        description: >
+          Mapping of directions to servers where DREAM data are located.
+          Each key corresponds to a direction (N, S, E, W, C) and maps to
+          a hostname.
+        type: object
+        properties:
+          N:
+            type: string
+          S:
+            type: string
+          E:
+            type: string
+          W:
+            type: string
+          C:
+            type: string
+          B:
+            type: string
+        required: [N, S, E, W, C, B]
+        additionalProperties: false
       data_product_path:
         description: Local filesystem path for fallback storage of data products
         type: string
       run_data_product_loop:
         description: If true, the CSC should collect data products from DREAM
+        type: boolean
+      skip_tmpdata_products:
+        description: >-
+          If true, the CSC should not save data products from DREAM that have
+          a file path starting with "/tmpdata/".
         type: boolean
     required:
       - host
@@ -85,9 +111,12 @@ CONFIG_SCHEMA = yaml.safe_load(
       - read_timeout
       - poll_interval
       - ess_index
+      - battery_low_threshold
       - s3instance
+      - data_product_host
       - data_product_path
       - run_data_product_loop
+      - skip_tmpdata_products
     additionalProperties: false
     """
 )

--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -148,7 +148,6 @@ class DreamCsc(salobj.ConfigurableCsc):
         if self.model is None:
             self.model = DreamModel(config=self.config, log=self.log)
         await self.model.connect(host=host, port=port)
-        await self.model.open_roof()
 
         self.weather_and_status_loop_task = asyncio.create_task(
             self.weather_and_status_loop()
@@ -157,15 +156,16 @@ class DreamCsc(salobj.ConfigurableCsc):
         if self.config.run_data_product_loop:
             self.data_product_loop_task = asyncio.create_task(self.data_product_loop())
 
-    async def end_enable(self, id_data: salobj.BaseDdsDataType) -> None:
-        """End do_enable; called after state changes but before command
+    async def end_start(self, id_data: salobj.BaseMsgType) -> None:
+        """End do_start; called after state changes but before command
         acknowledged.
 
-        This method connects to the DREAM Instrument and starts it.
+        This method connects to the DREAM Instrument and starts it. It
+        does not issue setRoof, because that happens during enable.
 
         Parameters
         ----------
-        id_data : `CommandIdData`
+        id_data : `salobj.BaseMsgType`
             Command ID and data
         """
         if not self.config:
@@ -183,17 +183,34 @@ class DreamCsc(salobj.ConfigurableCsc):
                 self.log.exception(err_msg)
                 await self.fault(code=ErrorCode.TCPIP_CONNECT_ERROR, report=err_msg)
 
-        await super().end_enable(id_data)
+        await super().end_start(id_data)
 
-    async def begin_disable(self, id_data: salobj.BaseDdsDataType) -> None:
-        """Begin do_disable; called before state changes.
+    async def end_enable(self, id_data: salobj.BaseMsgType) -> None:
+        """End do_enable; called after state changes but before command
+        acknowledged.
 
-        This method will try to gracefully stop the ESS Instrument and then
-        disconnect from it.
+        This method issues setRoof open to DREAM.
 
         Parameters
         ----------
-        id_data : `CommandIdData`
+        id_data : `salobj.BaseMsgType`
+            Command ID and data
+        """
+        if self.model is None:
+            raise RuntimeError("No model connected.")
+
+        await self.model.open_roof()
+        await super().end_enable(id_data)
+
+    async def begin_standby(self, id_data: salobj.BaseMsgType) -> None:
+        """Begin do_standby; called before state changes.
+
+        This method will try to gracefully stop the ESS Instrument and then
+        disconnect from it, and disconnect from the DREAM TCP server.
+
+        Parameters
+        ----------
+        id_data : `salobj.BaseMsgType`
             Command ID and data
         """
         await self.cmd_disable.ack_in_progress(id_data, timeout=SAL_TIMEOUT)
@@ -204,6 +221,22 @@ class DreamCsc(salobj.ConfigurableCsc):
             pass
 
         await self.disconnect()
+        await super().begin_standby(id_data)
+
+    async def begin_disable(self, id_data: salobj.BaseMsgType) -> None:
+        """Begin do_disable; called before state changes.
+
+        This method will close the roof with the setRoof command.
+
+        Parameters
+        ----------
+        id_data : `CommandIdData`
+            Command ID and data
+        """
+        if self.model is None:
+            raise RuntimeError("No model connected.")
+
+        await self.model.close_roof()
         await super().begin_disable(id_data)
 
     async def disconnect(self, close_roof: bool = True) -> None:

--- a/python/lsst/ts/dream/csc/mock/mock_dream.py
+++ b/python/lsst/ts/dream/csc/mock/mock_dream.py
@@ -234,8 +234,7 @@ class MockDream(tcpip.OneClientServer):
 
         # Weather information data used for determining whether the hatch can
         # be opened or not.
-        self.safe_observing_conditions: bool = False
-        self.cloud_cover: int = 0
+        self.roof: bool = False
 
         super().__init__(
             name=self.name,
@@ -443,6 +442,7 @@ class MockDream(tcpip.OneClientServer):
                 "result": "error",
                 "reason": "data required",
             }
+        self.roof = data  # Record state for check in unit testing
         return dict()
 
     async def heartbeat(self, data: bool | None) -> dict:

--- a/tests/config/_init.yaml
+++ b/tests/config/_init.yaml
@@ -6,5 +6,13 @@ poll_interval: 10
 ess_index: 301
 battery_low_threshold: 25
 s3instance: test
+data_product_host:
+  N: 127.0.0.1:5001
+  S: 127.0.0.1:5001
+  E: 127.0.0.1:5001
+  W: 127.0.0.1:5001
+  C: 127.0.0.1:5001
+  B: 127.0.0.1:5001
 data_product_path: /tmp
 run_data_product_loop: true
+skip_tmpdata_products: false

--- a/tests/test_dream_csc.py
+++ b/tests/test_dream_csc.py
@@ -128,6 +128,23 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 subsystemVersions="",
             )
 
+    async def test_disable(self):
+        logging.info("test_dome_telemetry")
+        async with self.make_csc(
+            initial_state=salobj.State.STANDBY,
+            config_dir=TEST_CONFIG_DIR,
+            simulation_mode=1,
+        ):
+            self.assertFalse(self.srv.roof)
+            await self.remote.cmd_start.set_start()
+            self.assertFalse(self.srv.roof)
+            await self.remote.cmd_enable.set_start()
+            self.assertTrue(self.srv.roof)  # setRoof=true should have been issued
+            await self.remote.cmd_disable.set_start()
+            self.assertFalse(self.srv.roof)
+            await self.remote.cmd_standby.set_start()
+            self.assertFalse(self.srv.roof)
+
     async def test_dome_telemetry(self):
         logging.info("test_dome_telemetry")
         async with self.make_csc(


### PR DESCRIPTION
This PR encompasses the following additions:
- Allows DREAM to obtain data products from multiple HTTP servers, specified in the CSC configuration.
- Adds a function to exclude upload of raw data products to the LFA.
- Refinement of unit tests to prevent them from hanging.
- Separation of the open roof command so that cmd_start only connects and cmd_enable opens the roof.