### PR TITLE
Tickets/osw 603

### DIFF
--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -26,6 +26,7 @@ import enum
 import io
 import pathlib
 import time
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, Union
 
@@ -694,8 +695,14 @@ class DreamCsc(salobj.ConfigurableCsc):
 
         # Set up an LFA bucket key
         product_type = "" if data_product.type is None else f"_{data_product.type}"
+
+        start_time = datetime.fromtimestamp(data_product.start, tz=timezone.utc)
+        start_time_str = start_time.isoformat(timespec="milliseconds").replace(
+            "+00:00", ""
+        )
+
         other = (
-            f"{data_product.start.tai.isot}_{data_product.server}_"
+            f"{start_time_str}_{data_product.server}_"
             f"{data_product.kind}{product_type}_"
             f"{data_product.seq[0]:06d}_{data_product.seq[-1]:06d}"
         )
@@ -703,7 +710,7 @@ class DreamCsc(salobj.ConfigurableCsc):
             salname=self.salinfo.name,
             salindexname=None,
             generator="dream",
-            date=data_product.start,
+            date=start_time_str,
             other=other,
             suffix=pathlib.Path(data_product.filename).suffix,
         )

--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -701,6 +701,11 @@ class DreamCsc(salobj.ConfigurableCsc):
 
         timeout = httpx.Timeout(300.0)
         async with httpx.AsyncClient(timeout=timeout) as client:
+            # First get the headers to check for redirect.
+            head = await client.get(dream_url, follow_redirects=True)
+            head.raise_for_status()
+            dream_url = str(head.url)
+
             async with client.stream("GET", dream_url) as response:
                 response.raise_for_status()
 

--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -709,9 +709,9 @@ class DreamCsc(salobj.ConfigurableCsc):
                     # First attempt: Save to S3
                     await self.save_to_s3(response, key)
                     return  # Success!
-                except Exception:
+                except Exception as ex:
                     self.log.exception(
-                        f"Could not upload {key} to S3; trying to save to local disk."
+                        f"Could not upload {key} to S3: {ex!r}; trying to save to local disk."
                     )
                     await self.save_to_local_disk(response, key)
 

--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -375,12 +375,8 @@ class DreamCsc(salobj.ConfigurableCsc):
                     self.log.debug(f"New data product: {data_product.filename}")
                     try:
                         await self.upload_data_product(data_product)
-                    except Exception as e:
+                    except Exception:
                         self.log.exception("Upload data product failed")
-                        err_msg = f"Failed to upload DREAM data product: {e!r}"
-                        await self.fault(
-                            code=ErrorCode.UPLOAD_DATA_PRODUCT_FAILED, report=err_msg
-                        )
 
             await asyncio.sleep(self.config.poll_interval)
 

--- a/python/lsst/ts/dream/csc/mock/mock_ess.py
+++ b/python/lsst/ts/dream/csc/mock/mock_ess.py
@@ -29,7 +29,7 @@ from lsst.ts import salobj
 class MockWeather(salobj.BaseCsc):
     """A very limited fake weather CSC
 
-    It emits tel_airflow and evt_precipitation.
+    It emits tel_airflow, tel_relativeHumidity and evt_precipitation.
 
     Parameters
     ----------
@@ -81,6 +81,12 @@ class MockWeather(salobj.BaseCsc):
 
     async def telemetry_loop(self) -> None:
         while True:
+            await self.tel_relativeHumidity.set_write(
+                sensorName="",
+                timestamp=0,
+                relativeHumidityItem=50,
+                location="",
+            )
             await self.tel_airFlow.set_write(
                 sensorName="",
                 timestamp=0,

--- a/python/lsst/ts/dream/csc/model/dream_model.py
+++ b/python/lsst/ts/dream/csc/model/dream_model.py
@@ -115,6 +115,7 @@ class DreamModel:
         if not self.connected:
             raise RuntimeError("Not connected")
 
+        self.client._reader._limit = 100_000_000
         data = await asyncio.wait_for(
             self.client.read_json(), timeout=self.config.read_timeout
         )

--- a/tests/test_dream_csc.py
+++ b/tests/test_dream_csc.py
@@ -292,10 +292,10 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 file_contents = fileobj.getvalue().decode("utf-8")
 
                 file_index = [
-                    "N_cloud_flat_000041_000073.txt",
-                    "W_cloud_science_000019_000056.txt",
-                    "S_calibration_000057_000047.txt",
-                    "B_image_bias_000017_000080.txt",
+                    "DREAM_dream_2025-02-14T21:03:32.206_N_cloud_flat_000041_000073.txt",
+                    "DREAM_dream_2025-02-14T21:03:32.207_W_cloud_science_000019_000056.txt",
+                    "DREAM_dream_2025-02-14T21:03:32.207_S_calibration_000057_000047.txt",
+                    "DREAM_dream_2025-02-14T21:03:32.207_B_image_bias_000017_000080.txt",
                 ]
                 for j, key_ending in enumerate(file_index):
                     if key.endswith(key_ending):

--- a/tests/test_dream_csc.py
+++ b/tests/test_dream_csc.py
@@ -152,7 +152,9 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             config_dir=TEST_CONFIG_DIR,
             simulation_mode=1,
         ):
-            dome_telemetry = await self.remote.tel_dome.next(flush=False)
+            dome_telemetry = await self.remote.tel_dome.next(
+                timeout=STD_TIMEOUT, flush=False
+            )
             self.assertEqual(dome_telemetry.encoder, 110)
 
     async def test_environment_telemetry(self):
@@ -162,7 +164,9 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             config_dir=TEST_CONFIG_DIR,
             simulation_mode=1,
         ):
-            environment_telemetry = await self.remote.tel_environment.next(flush=False)
+            environment_telemetry = await self.remote.tel_environment.next(
+                flush=False, timeout=STD_TIMEOUT
+            )
             self.assertAlmostEqual(
                 environment_telemetry.temperature[0], 25.9606, places=4
             )
@@ -183,7 +187,9 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             config_dir=TEST_CONFIG_DIR,
             simulation_mode=1,
         ):
-            power_supply_telemetry = await self.remote.tel_powerSupply.next(flush=False)
+            power_supply_telemetry = await self.remote.tel_powerSupply.next(
+                flush=False, timeout=STD_TIMEOUT
+            )
             self.assertAlmostEqual(power_supply_telemetry.voltage[0], 0.0405, places=4)
             self.assertAlmostEqual(power_supply_telemetry.voltage[1], 0.0, places=4)
             self.assertAlmostEqual(
@@ -198,7 +204,10 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             config_dir=TEST_CONFIG_DIR,
             simulation_mode=1,
         ):
-            ups_telemetry = await self.remote.tel_ups.next(flush=False)
+            ups_telemetry = await self.remote.tel_ups.next(
+                timeout=STD_TIMEOUT,
+                flush=False,
+            )
             self.assertAlmostEqual(ups_telemetry.batteryCharge, 100.0)
 
     async def test_alerts_event(self):

--- a/tests/test_dream_csc.py
+++ b/tests/test_dream_csc.py
@@ -293,6 +293,7 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                         self.assertEqual(file_contents, f"This is data product {j+1}")
                         break
 
+    @unittest.expectedFailure
     async def test_data_upload_failure(self):
         """Test that the CSC enters FAULT state if the data upload fails."""
         logging.info("test_data_upload_failure")
@@ -313,6 +314,7 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 await self.assert_next_summary_state(salobj.State.ENABLED)
                 await self.assert_next_summary_state(salobj.State.FAULT)
 
+    @unittest.expectedFailure
     async def test_data_download_failure(self):
         """Test that the CSC enters FAULT state if the data upload fails."""
         logging.info("test_data_upload_failure")


### PR DESCRIPTION
This patch adds the following:
- Increases the maximum data size for tcpip, to accomodate large getNewDataProduct messages
- Ensures that HTTP redirects are followed
- Prevents the CSC from faulting if an image upload fails
- Corrects some random bugs:
  * Stops the monitor loops before disconnecting, instead of after
  * Avoids raising when weather telemetry is not available
- Adds timeouts in the unit tests to prevent the Jenkins build from stalling