### PR TITLE
OSW-677: DREAM uploads duplicate data products

### DIFF
--- a/python/lsst/ts/dream/csc/dream_csc.py
+++ b/python/lsst/ts/dream/csc/dream_csc.py
@@ -730,6 +730,7 @@ class DreamCsc(salobj.ConfigurableCsc):
             f"{start_time_str}_{data_product.server}_"
             f"{data_product.kind}{product_type}_"
             f"{data_product.seq[0]:06d}_{data_product.seq[-1]:06d}"
+            f"_r{data_product.revision}"
         )
         key = self.s3bucket.make_key(
             salname=self.salinfo.name,

--- a/python/lsst/ts/dream/csc/model/dream_model.py
+++ b/python/lsst/ts/dream/csc/model/dream_model.py
@@ -40,6 +40,7 @@ class DataProduct:
     seq: list[int]
     start: float
     end: float
+    revision: int
     server: Literal["N", "E", "S", "W", "C", "B"]
     size: int  # in bytes
     filename: str
@@ -69,6 +70,10 @@ class DataProduct:
             datetime.fromisoformat(data["end"]).replace(tzinfo=timezone.utc).timestamp()
         )
         data["end"] = utils.tai_from_utc_unix(end_time)
+
+        if "revision" not in data:
+            data["revision"] = 0
+
         return cls(**data)
 
 

--- a/tests/test_dream_csc.py
+++ b/tests/test_dream_csc.py
@@ -24,6 +24,7 @@
 import asyncio
 import contextlib
 import logging
+import os
 import pathlib
 import unittest
 
@@ -42,6 +43,8 @@ logging.basicConfig(
 
 
 class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
+    _randomize_topic_subname = True
+
     async def asyncSetUp(self) -> None:
         await super().asyncSetUp()
 
@@ -66,8 +69,9 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         await super().asyncTearDown()
 
     def basic_make_csc(
-        self, initial_state, config_dir, simulation_mode, override, **kwargs
+        self, initial_state, config_dir, simulation_mode, override="", **kwargs
     ):
+        logging.error(os.environ["LSST_TOPIC_SUBNAME"])
         return dream_csc.DreamCsc(
             initial_state=initial_state,
             config_dir=config_dir,


### PR DESCRIPTION
- After discussion on Slack, it seems DREAM will sometimes send duplicate copies of the same data, and the re-sent data can potentially be very stale. To keep everything straight, a revision keyword will be added to the new data products structure. This change anticipates the revision keyword. If absent, the revision is assumed to be zero. (see thread at https://discovery-alliance.slack.com/archives/C01LH9NE18W/p1754492405117719)
- Additionally, some cleanup is added for the CSC testing. The Jenkins server has had trouble with Kafka topics not getting deleted after the test run. I'm not sure this will do anything to solve the problem, but it shouldn't hurt either.