### PR TITLE
OSW-1824: Avoid DREAM fault when missing weather telemetry.

### DIFF
--- a/doc/news/OSW-1824.bugfix.rst
+++ b/doc/news/OSW-1824.bugfix.rst
@@ -1,0 +1,1 @@
+Avoided fault in case of missing weather telemetry by reporting bad weather to DREAM instead.


### PR DESCRIPTION
This change resolves the problem of DREAM faulting when ESS:301 is unavailable. Instead, it sends weather bad flags to the DREAM until such time as ESS:301 resumes sending telemetry.